### PR TITLE
Fix nil pointer exception

### DIFF
--- a/libs/ecs/ecs.go
+++ b/libs/ecs/ecs.go
@@ -251,12 +251,12 @@ func updateTargetTaskDefinition(task *Task) error {
 	}
 
 	shouldUpdateTaskDef := false
-	if *targetTaskDef.TaskRoleArn != *sourceTaskDef.TaskRoleArn {
+	if !reflect.DeepEqual(sourceTaskDef.TaskRoleArn, targetTaskDef.TaskRoleArn) {
 		targetTaskDef.TaskRoleArn = sourceTaskDef.TaskRoleArn
 		shouldUpdateTaskDef = true
 	}
 
-	if *targetTaskDef.ExecutionRoleArn != *sourceTaskDef.ExecutionRoleArn {
+	if !reflect.DeepEqual(sourceTaskDef.ExecutionRoleArn, targetTaskDef.ExecutionRoleArn) {
 		targetTaskDef.ExecutionRoleArn = sourceTaskDef.ExecutionRoleArn
 		shouldUpdateTaskDef = true
 	}

--- a/scripts/run-ecs-task.go
+++ b/scripts/run-ecs-task.go
@@ -72,7 +72,7 @@ func getRequiredEnv() (RequiredEnv, error) {
 
 
 func main() {
-	log.Println("Version 0.0.11")
+	log.Println("Version 0.0.12")
 	sigs := make(chan os.Signal, 1)
 	done := make(chan bool, 1)
 	signal.Notify(sigs, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM)


### PR DESCRIPTION
### Issue:
- If `targetTaskDef.ExecutionRoleArn` is `nil`, then dereferencing the pointer `targetTaskDef.ExecutionRoleArn` will cause a nil pointer exception.